### PR TITLE
feat: enable trigger workflow manually

### DIFF
--- a/.github/workflows/cloud.yml
+++ b/.github/workflows/cloud.yml
@@ -1,6 +1,8 @@
 name: (Cloud)Kernel Builder Xiaomi 10 Ultra
 
-on: [push]
+on:
+  - push
+  - workflow_dispatch
 
 jobs:
   build:


### PR DESCRIPTION
# Background
Github action support trigger Github Action on the Web page manually. Due to the artifacts also expired, we need to re-run the job. It's easier to re-run a job to re-generate the assets for users.
For the `workflow_dispatch` trigger, see the document [here](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch).

# Changes
Add trigger to workflows.